### PR TITLE
bundle update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
     msgpack (1.3.1)
     mysql2 (0.5.2)
     nio4r (2.4.0)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     parallel (1.17.0)
     parser (2.6.3.0)


### PR DESCRIPTION
* `nokogiri`
  * CHANGELOG
    * A command injection vulnerability in Nokogiri v1.10.3 and earlier allows commands to be executed in a subprocess by Ruby's `Kernel.open` method. Processes are vulnerable only if the undocumented method `Nokogiri::CSS::Tokenizer#load_file` is being passed untrusted user input.

    * This vulnerability appears in code generated by the Rexical gem versions v1.0.6 and earlier. Rexical is used by Nokogiri to generate lexical scanner code for parsing CSS queries. The underlying vulnerability was addressed in Rexical v1.0.7 and Nokogiri upgraded to this version of Rexical in Nokogiri v1.10.4.

    * This CVE's public notice is https://github.com/sparklemotion/nokogiri/issues/1915
  * Compare URL
    * https://github.com/sparklemotion/nokogiri/compare/v1.10.3...v1.10.4