### PR TITLE
bundle update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,9 +192,8 @@ GEM
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     rubyzip (1.2.3)
-    sassc (2.0.1)
+    sassc (2.1.0)
       ffi (~> 1.9)
-      rake
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)


### PR DESCRIPTION
* `sassc`
  - CHANGELOG
    - **2.1.0**
      - Equivalent to 2.1.0.pre3
    - **2.1.0.pre3**
      - [extconf.rb: Always write VERSION if we have .git](https://github.com/sass/sassc-ruby/pull/131)
      - [Update libsass to 3.6.1](https://github.com/sass/sassc-ruby/pull/130)
    - **2.1.0.pre2**
      - [Reduce Ruby warnings](https://github.com/sass/sassc-ruby/pull/124)
      - [prefer equal? to determine object identity](https://github.com/sass/sassc-ruby/pull/122)
      - [Link C/C++ stdlib statically for binary gems](https://github.com/sass/sassc-ruby/pull/127)
    - **2.1.0.pre1**
      - [Update Libsass to 3.6.0](https://github.com/sass/sassc-ruby/pull/96/files)
      - [Support old Ruby versions](https://github.com/sass/sassc-ruby/pull/117/files)
  - Compare URL
    - https://github.com/sass/sassc-ruby/compare/v2.0.1...v2.1.0